### PR TITLE
0.1.9 don't use an empty Authorization header 

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+0.1.9
+  date: 2018-03-02
+  - don't use an empty Authorization header (since the default token is null)
+
 0.1.8
   date: 2018-03-02
   changes:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vimeo-upload",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "Upload videos to your Vimeo account and update their metadata directly from a browser or a Node.js app.",
   "main": "vimeo-upload.js",
   "homepage": "https://github.com/ecoach-lms/vimeo-upload#readme",

--- a/vimeo-upload.js
+++ b/vimeo-upload.js
@@ -191,7 +191,9 @@
     me.prototype.upload = function() {
         var xhr = new XMLHttpRequest()
         xhr.open(this.httpMethod, this.url, true)
-        xhr.setRequestHeader('Authorization', 'Bearer ' + this.token)
+        if (this.token) {
+          xhr.setRequestHeader('Authorization', 'Bearer ' + this.token)
+        }
         xhr.setRequestHeader('Content-Type', 'application/json')
         xhr.setRequestHeader('Accept', this.accept)
 


### PR DESCRIPTION
(since the default token is null)